### PR TITLE
Add block logg in to fb/google from test app

### DIFF
--- a/user/functions.py
+++ b/user/functions.py
@@ -136,3 +136,6 @@ def login_from_messenger_check(initial_function):
 		
         return initial_function(*args, **kwargs)
     return wrapped_function
+
+
+

--- a/user/routes.py
+++ b/user/routes.py
@@ -389,6 +389,10 @@ def rotate_avatar_left():
 @user.route("/google-login")
 def loginGoogle():
 
+    if "127.0.0.1:5000" or "test" in request.base_url:
+        flash("Ta funkcjonalność dostępna wyłącznie w aplikacji produkcyjnej.", 'danger')
+        return redirect(url_for('user.login'))
+
     #Gogole
     os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
     flow = Flow.from_client_config(client_config = google_client_config,
@@ -451,6 +455,10 @@ def callbackGoogle():
 @user.route("/fb-login")
 def loginFacebook():
 
+    if "127.0.0.1:5000" or "test" in request.base_url:
+        flash("Ta funkcjonalność dostępna wyłącznie w aplikacji produkcyjnej.", 'danger')
+        return redirect(url_for('user.login'))
+
     facebook = requests_oauthlib.OAuth2Session(FB_CLIENT_ID, redirect_uri=URL + "/fb-callback", scope=FB_SCOPE)
     authorization_url, _ = facebook.authorization_url(FB_AUTHORIZATION_BASE_URL)
 
@@ -459,7 +467,6 @@ def loginFacebook():
 
 @user.route("/fb-callback", methods=['GET'])
 def callback():
-
 
     try:
         if "error" not in request.args:


### PR DESCRIPTION
See: #123

![image](https://user-images.githubusercontent.com/98742733/211411953-90f6ead8-239d-490e-873e-aa221a9e079f.png)
Prosi się, żeby to zrobić w formie wrappera ale coś mi te wrappery nie chcą działać. Podobnie jak ten wrapper do sprawdzania czy user loguje sie do fb/google przez messengera. Kiedyś to działało ale teraz coś nie chce. 