### PR TITLE
Fixes "Join event" button on dashboard (mobile)

### DIFF
--- a/static/styles/dashboard_your_events.css
+++ b/static/styles/dashboard_your_events.css
@@ -17,6 +17,8 @@
 .Event-Box-Row {
     display: flex;
     flex-direction: row;
+    padding-left: 15px;
+    padding-right: 15px;
     justify-content: center;
 }
 
@@ -43,7 +45,9 @@
     border: 2px solid #000;
     padding: 5px;
     padding-top: 15px;
-    padding-bottom: 15px;
+    padding-bottom: 10px;
+    padding-left: 15px;
+    padding-right: 15px;
 }
 
 
@@ -105,13 +109,12 @@
     display: flex;
     width: 60%;
     max-width: 399px;
-    height: 56px;
     margin: auto !important;
     border-radius: 15px;
     background-color: #579956 !important;
     margin-top: 200px;
     margin-left: auto;
-    margin-right: auto;
+    margin-bottom: 10px;
     border: solid 2px #579956;
     justify-content: center;
     position: relative;
@@ -159,6 +162,13 @@
         height: 35px;
     
       }
+
+    .Main-Button {
+        width: 90%;
+        font-size: 16px;
+
+    }
+
 
 }
 


### PR DESCRIPTION
See: #290

Tak to wygląda:
![image](https://user-images.githubusercontent.com/98431180/212417713-19a03ef0-ce4a-42a9-9680-5d0111398fd5.png)

Nie jest idealnie, bo jak ktoś będzie miał bardzo mały ekran to prawdopodobnie zrobi się coś takiego, jak poniżej. Ale to raczej mało przypadków, a jak wiadomo orłami CSS nie jesteśmy.

![image](https://user-images.githubusercontent.com/98431180/212417793-34dad37d-a9f6-4a87-9375-666006a4a220.png)
